### PR TITLE
Fix: up to date with bashate

### DIFF
--- a/flycheck-bashate.el
+++ b/flycheck-bashate.el
@@ -5,6 +5,7 @@
 ;; Author: Alex Murray <murray.alex@gmail.com>
 ;; Maintainer: Alex Murray <murray.alex@gmail.com>
 ;; URL: https://github.com/alexmurray/flycheck-bashate
+;; Package-Version: 20160630.440
 ;; Version: 0.1
 ;; Package-Requires: ((flycheck "0.24") (emacs "24.4"))
 
@@ -41,12 +42,16 @@
 (flycheck-define-checker bashate
   "A checker using bashate.
 
-See `https://github.com/alexmurray/bashate/'."
+See `https://github.com/openstack/bashate/'."
   :command ("bashate" source)
   :error-patterns ((error line-start "[E] "(message (minimal-match (one-or-more not-newline))) ": '" (one-or-more not-newline) "'\n"
                           " - " (file-name) " : L" line line-end)
                    (warning line-start "[W] "(message (minimal-match (one-or-more not-newline))) ": '" (one-or-more not-newline) "'\n"
-                            " - " (file-name) " : L" line line-end))
+                            " - " (file-name) " : L" line line-end)
+                   (error line-start (file-name) ":" line ":" column ":" " E040"
+                          (message (minimal-match (one-or-more not-newline)) line-end))
+                   (warning line-start (file-name) ":" line ":" column ":" " E"
+                            (message (minimal-match (one-or-more not-newline)) line-end)))
   :modes sh-mode)
 
 ;;;###autoload

--- a/flycheck-bashate.el
+++ b/flycheck-bashate.el
@@ -5,7 +5,6 @@
 ;; Author: Alex Murray <murray.alex@gmail.com>
 ;; Maintainer: Alex Murray <murray.alex@gmail.com>
 ;; URL: https://github.com/alexmurray/flycheck-bashate
-;; Package-Version: 20160630.440
 ;; Version: 0.1
 ;; Package-Requires: ((flycheck "0.24") (emacs "24.4"))
 


### PR DESCRIPTION
Close #1 

bashate started to use pep8 format since July 2018